### PR TITLE
fix issue #1, now it should read the Input.

### DIFF
--- a/src/lib/paypal-angular.component.ts
+++ b/src/lib/paypal-angular.component.ts
@@ -41,8 +41,12 @@ export class PaypalAngularComponent implements OnInit {
   constructor(
     private paypalAngularService: PaypalAngularService
   ) {
-    const client = this.paypalAngularService.getConfig();
-    this.paypalConfig = {
+
+  }
+
+  ngOnInit() {
+     const client = this.paypalAngularService.getConfig();
+     this.paypalConfig = {
       locale: this.locale || this.default.locale,
       commit: this.commit || this.default.commit,
       env: this.env || this.default.env,
@@ -53,9 +57,8 @@ export class PaypalAngularComponent implements OnInit {
       payment: () => null,
       onAuthorize: () => null
     };
-  }
 
-  ngOnInit() {
+    
     if (this.payment) {
       this.paypalConfig.payment = this.payment;
     }


### PR DESCRIPTION
in angular, the constructer code is run before the component @Input are injected, which cause the default config to be static.

1 -> constructor(): code runs before @Input data value is injected from outside component
2-> ngOnInit(): code runs after @Input data value is injected